### PR TITLE
Update 'Season' property to valid string

### DIFF
--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -50,7 +50,7 @@
     ```
 
     ```js
-    nba.stats.allPlayers({ Season: '2014-2015' }, (err, res) => {
+    nba.stats.allPlayers({ Season: '2014-15' }, (err, res) => {
       if (err) {
         console.error(err);
         return;


### PR DESCRIPTION
Was getting an error that '2014-2015' needed to match this regexp: ^\\d{4}-\\d{2}$\. Updating the example to follow suit.