### PR TITLE
Add boxscore v2 endpoints

### DIFF
--- a/docs/api/STATS.md
+++ b/docs/api/STATS.md
@@ -40,6 +40,21 @@
       * `VsConference`
       * `VsDivision`
       * `Weight`
+
+  - `boxscoreSummary`
+    + Endpoint: [`/stats/boxscoresummaryv2`](http://stats.nba.com/stats/boxscoresummaryv2)
+    + Parameters:
+      * GameID
+
+  - `boxscoreTraditional`
+    + Endpoint: [`/stats/boxscoretraditionalv2`](http://stats.nba.com/stats/boxscoretraditionalv2)
+    + Parameters:
+      * `GameID`
+      * `EndPeriod`
+      * `EndRange`
+      * `RangeType`
+      * `StartPeriod`
+      * `StartRange`
     
   - `defenseHub`
     + Endpoint: [`/stats/defensehub`](http://stats.nba.com/stats/defensehub)
@@ -1077,6 +1092,9 @@
       * `'12'`
       * `'13'`
       * `'14'`
+  - `endRange`
+    + Possible values:
+      * `'0 - 2147483647'`
   - `gameDate`
     + Possible values:
       * `'MM/DD/YYYY'`
@@ -1211,6 +1229,11 @@
     + Possible values:
       * `'5'`
       * `'n'`
+  - `rangeType`
+    + Possible values:
+      * `'0'`
+      * `'1'`
+      * `'2'`
   - `scope`
     + Possible values:
       * `'S'`
@@ -1267,6 +1290,9 @@
       * `'12'`
       * `'13'`
       * `'14'`
+  - `startRange`
+    + Possible values:
+      * `'0 - 2147483647'`
   - `starterBench`
     + Possible values:
       * `null`

--- a/src/api/stats/constants/defaults.js
+++ b/src/api/stats/constants/defaults.js
@@ -10,6 +10,7 @@ const DEFAULTS = {
   draftYear: null,
   dribbleRange: null,
   endPeriod: 14,
+  endRange: 28800,
   gameDate: '04/20/2015',
   gameID: null,
   gameScope: 'Season',
@@ -34,6 +35,7 @@ const DEFAULTS = {
   playerScope: 'All Players',
   playoffRound: '0',
   pointDiff: '5',
+  rangeType: 0,
   scope: 'S',
   season: '2015-16',
   seasonSegment: null,
@@ -43,6 +45,7 @@ const DEFAULTS = {
   shotDistRange: null,
   sorter: 'PTS',
   startPeriod: 1,
+  startRange: 0,
   starterBench: null,
   statCategory: 'PTS',
   statType: 'Traditional',
@@ -93,6 +96,29 @@ export const ASSIST_TRACKER = {
     VsConference: DEFAULTS.conference,
     VsDivision: DEFAULTS.division,
     Weight: DEFAULTS.weight
+  }
+}
+
+export const BOXSCORE_SUMMARY_V2 = {
+  method: 'boxscoreSummary',
+  endpoint: '/stats/boxscoresummaryv2',
+  defaults: {
+    GameID: DEFAULTS.gameID
+  }
+}
+
+export const BOXSCORE_TRADITIONAL_V2 = {
+  method: 'boxscoreTraditional',
+  endpoint: '/stats/boxscoretraditionalv2',
+  defaults: {
+    EndPeriod: DEFAULTS.endPeriod,
+    EndRange: DEFAULTS.endRange,
+    GameID: DEFAULTS.gameID,
+    RangeType: DEFAULTS.rangeType,
+    Season: DEFAULTS.season,
+    SeasonType: DEFAULTS.seasonType,
+    StartPeriod: DEFAULTS.startPeriod,
+    StartRange: DEFAULTS.startRange
   }
 }
 


### PR DESCRIPTION
As mentioned at the end of #20, there are new boxscore endpoints: <code>/stats/boxscoresummaryv2</code> and <code>/stats/boxscoretraditionalv2</code>. These are now implemented.  